### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/rosatsch/ac2f3a96-47e5-4996-a5ac-c7795074af78/01b3acc1-1f87-4415-8e83-de473c9cbc3b/_apis/work/boardbadge/f79cb15c-7818-413e-aa0d-af4127c73700)](https://dev.azure.com/rosatsch/ac2f3a96-47e5-4996-a5ac-c7795074af78/_boards/board/t/01b3acc1-1f87-4415-8e83-de473c9cbc3b/Microsoft.RequirementCategory)
 # Add to Trello
 
 A chrome extension to make it easier to add cards to Trello from your browser.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#90](https://dev.azure.com/rosatsch/ac2f3a96-47e5-4996-a5ac-c7795074af78/_workitems/edit/90). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.